### PR TITLE
Fix build errors when building with latest zig version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.build.Builder) void {
     const test_step = b.step("test", "Run all the tests");
     test_step.dependOn(b.getInstallStep());
 
-    var tests = b.addTest(.{
+    const tests = b.addTest(.{
         .root_source_file = .{ .path = "tests/tests.zig" },
         .target = target,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "lspmm-zig",
     .version = "0.1.0",
-
+    .paths = .{"build.zig", "build.zig.zon", "src"},
     .dependencies = .{},
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -91,7 +91,7 @@ fn isOrActuallyEnum(ort: MetaModel.OrType) bool {
 
 fn isTypeNull(typ: MetaModel.Type) bool {
     if (typ != .@"or") return false;
-    var ort = typ.@"or";
+    const ort = typ.@"or";
     return (ort.items.len == 2 and ort.items[1] == .base and ort.items[1].base.name == .null) or (ort.items[ort.items.len - 1] == .base and ort.items[ort.items.len - 1].base.name == .null);
 }
 
@@ -163,7 +163,7 @@ fn writeType(meta_model: MetaModel, writer: anytype, typ: MetaModel.Type) @TypeO
                 }
                 try writer.writeByte('}');
             } else {
-                var has_null = ort.items[ort.items.len - 1] == .base and ort.items[ort.items.len - 1].base.name == .null;
+                const has_null = ort.items[ort.items.len - 1] == .base and ort.items[ort.items.len - 1].base.name == .null;
 
                 if (has_null) try writer.writeByte('?');
 


### PR DESCRIPTION
Hi! I noticed this project doesn't build with the latest version of zig, `0.12.0-dev.1751+7fbbeae61.` 

Changes:
- Replace unnecessary use of 'var' with 'const'
- Include paths field in build.zig.zon