### PR TITLE
Zig master `builtin` type field changes

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -134,7 +134,7 @@ pub fn EnumCustomStringValues(comptime T: type, comptime contains_empty_enum: bo
 
         const kvs = build_kvs: {
             const KV = struct { []const u8, T };
-            const fields = @typeInfo(T).Union.fields;
+            const fields = std.meta.fields(T);
             var kvs_array: [fields.len - 1]KV = undefined;
             for (fields[0 .. fields.len - 1], &kvs_array) |field, *kv| {
                 if (contains_empty_enum and std.mem.eql(u8, field.name, "empty")) {
@@ -362,7 +362,7 @@ fn expectParseEqual(comptime T: type, comptime expected: anytype, s: []const u8)
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    if (@typeInfo(@TypeOf(expected)) != .ErrorSet) {
+    if (@typeInfo(@TypeOf(expected)) != .error_set) {
         const actual_from_slice = try std.json.parseFromSliceLeaky(T, arena, s, .{});
         try std.testing.expectEqualDeep(@as(T, expected), actual_from_slice);
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -362,7 +362,10 @@ fn expectParseEqual(comptime T: type, comptime expected: anytype, s: []const u8)
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    if (@typeInfo(@TypeOf(expected)) != .error_set) {
+    const std_builtin_type_rename = comptime std.SemanticVersion.parse("0.14.0-dev.1346+31fef6f11") catch unreachable;
+    const error_set_tag = comptime if (@import("builtin").zig_version.order(std_builtin_type_rename) == .lt) .ErrorSet else .error_set;
+
+    if (@typeInfo(@TypeOf(expected)) != error_set_tag) {
         const actual_from_slice = try std.json.parseFromSliceLeaky(T, arena, s, .{});
         try std.testing.expectEqualDeep(@as(T, expected), actual_from_slice);
 


### PR DESCRIPTION
Update to work with latest Zig master. In particular, PR 21225. Required for corresponding ZLS update.