### PR TITLE
Update build.zig.zon for new package hash format (Zig `0.14.0-dev.3445+6c3cbb0c8`)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "lsp-codegen",
+    .name = .lsp_codegen,
     .version = "0.1.0",
     .minimum_zig_version = "0.12.0",
     .dependencies = .{},
@@ -11,4 +11,5 @@
         "LICENSE",
         "README.md",
     },
+    .fingerprint = 0x8c3c9a6459133f92,
 }


### PR DESCRIPTION
* `-` no longer allowed in `.name` fields
* `.fingerprint` value is as suggested by `zig build`