### PR TITLE
Provide a textDocument/completion example

### DIFF
--- a/examples/my_first_server.zig
+++ b/examples/my_first_server.zig
@@ -109,6 +109,7 @@ pub const Handler = struct {
                 },
             },
             .hoverProvider = .{ .bool = true },
+            .completionProvider = .{ .triggerCharacters = &[_][]const u8{"."} },
         };
 
         // Tries to validate that our server capabilities are actually implemented.
@@ -254,6 +255,36 @@ pub const Handler = struct {
                 },
             },
         };
+    }
+
+    // Return autocomplete options when a user types one of the
+    // `triggerCharacters` listed in `server_capabilities`.
+    pub fn @"textDocument/completion"(
+        _: *Handler,
+        arena: std.mem.Allocator,
+        params: lsp.types.CompletionParams,
+    ) error{OutOfMemory}!lsp.ResultType("textDocument/completion") {
+        std.log.debug("Received 'textDocument/completion' notification", .{});
+
+        if (params.context) |context| {
+            std.log.info("completion triggered by {any} {s}", .{
+                context.triggerCharacter,
+                @tagName(context.triggerKind),
+            });
+        }
+
+        var completions = try arena.alloc(lsp.types.CompletionItem, 2);
+        completions[0] = .{
+            .label = "get",
+            .detail = "get the value",
+            .insertText = "get",
+        };
+        completions[1] = .{
+            .label = "set",
+            .detail = "set the value",
+            .insertText = "set",
+        };
+        return .{ .array_of_CompletionItem = completions };
     }
 
     /// We received a response message from the client/editor.

--- a/examples/my_first_server.zig
+++ b/examples/my_first_server.zig
@@ -109,7 +109,7 @@ pub const Handler = struct {
                 },
             },
             .hoverProvider = .{ .bool = true },
-            .completionProvider = .{ .triggerCharacters = &[_][]const u8{"."} },
+            .completionProvider = .{ .triggerCharacters = &.{"."} },
         };
 
         // Tries to validate that our server capabilities are actually implemented.

--- a/examples/my_first_server.zig
+++ b/examples/my_first_server.zig
@@ -267,9 +267,9 @@ pub const Handler = struct {
         std.log.debug("Received 'textDocument/completion' notification", .{});
 
         if (params.context) |context| {
-            std.log.info("completion triggered by {any} {s}", .{
+            std.log.info("completion triggered by {?s} {t}", .{
                 context.triggerCharacter,
-                @tagName(context.triggerKind),
+                context.triggerKind,
             });
         }
 

--- a/examples/my_first_server.zig
+++ b/examples/my_first_server.zig
@@ -257,8 +257,6 @@ pub const Handler = struct {
         };
     }
 
-    // Return autocomplete options when a user types one of the
-    // `triggerCharacters` listed in `server_capabilities`.
     pub fn @"textDocument/completion"(
         _: *Handler,
         arena: std.mem.Allocator,

--- a/examples/my_first_server.zig
+++ b/examples/my_first_server.zig
@@ -273,17 +273,16 @@ pub const Handler = struct {
             });
         }
 
-        var completions = try arena.alloc(lsp.types.CompletionItem, 2);
-        completions[0] = .{
-            .label = "get",
-            .detail = "get the value",
-            .insertText = "get",
-        };
-        completions[1] = .{
-            .label = "set",
-            .detail = "set the value",
-            .insertText = "set",
-        };
+        const completions = try arena.dupe(lsp.types.CompletionItem, &.{
+            .{
+                .label = "get",
+                .detail = "get the value",
+            },
+            .{
+                .label = "set",
+                .detail = "set the value",
+            },
+        });
         return .{ .array_of_CompletionItem = completions };
     }
 


### PR DESCRIPTION
In case it might be helpful, this adds an example completion provider to the `my_first_server.zig` example code.

*(This patch is public domain and can be freely used in any code under any license.)*