### PR TITLE
Update build args and find program for API changes

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.16.0
+          version: master
 
       - name: Generate Documentation
         run: zig build docs --summary all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.16.0
+          version: master
 
       - name: Setup kcov
         if: github.repository_owner == 'zigtools' && matrix.os == 'ubuntu-22.04'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Provides the necessary building blocks to develop Language Server Protocol imple
 # Installation
 
 > [!NOTE]
-> The default branch requires Zig `0.16.0` or later.
+> The default branch requires Zig `0.17.0-dev.607+456b2ec07` or later.
 
 ```bash
 # Initialize a `zig build` project if you haven't already

--- a/build.zig
+++ b/build.zig
@@ -170,7 +170,7 @@ pub fn build(b: *std.Build) void {
 
     const kcov_bin = b.findProgramLazy(.{
         .names = &.{"kcov"},
-    }) orelse @panic("Failed to find kcov");
+    });
 
     const kcov_merge = std.Build.Step.Run.create(b, "kcov merge coverage");
     kcov_merge.rename_step_with_output_arg = false;

--- a/build.zig
+++ b/build.zig
@@ -118,11 +118,13 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(hello_client_exe);
 
     const run_hello_client = b.addRunArtifact(hello_client_exe);
-    if (b.args) |args| {
-        run_hello_client.addArgs(args);
-        if (args.len == 1) {
-            run_hello_client.addArtifactArg(hello_server_exe);
-        }
+    run_hello_client.addPassthruArgs();
+
+    const server_path_opt = b.option([]const u8, "server_path", "Set server path for run-hello-client");
+    if (server_path_opt) |server_path| {
+        run_hello_client.addArg(server_path);
+    } else {
+        run_hello_client.addArtifactArg(hello_server_exe);
     }
 
     const run_hello_client_step = b.step("run-hello-client", "Run the hello-client example");
@@ -166,7 +168,9 @@ pub fn build(b: *std.Build) void {
 
     // ----------------------------- Code Coverage -----------------------------
 
-    const kcov_bin = b.findProgram(&.{"kcov"}, &.{}) catch "kcov";
+    const kcov_bin = b.findProgram(.{
+        .names = &.{"kcov"},
+    }) orelse "kcov";
 
     const kcov_merge = std.Build.Step.Run.create(b, "kcov merge coverage");
     kcov_merge.rename_step_with_output_arg = false;

--- a/build.zig
+++ b/build.zig
@@ -168,19 +168,19 @@ pub fn build(b: *std.Build) void {
 
     // ----------------------------- Code Coverage -----------------------------
 
-    const kcov_bin = b.findProgram(.{
+    const kcov_bin = b.findProgramLazy(.{
         .names = &.{"kcov"},
-    }) orelse "kcov";
+    }) orelse @panic("Failed to find kcov");
 
     const kcov_merge = std.Build.Step.Run.create(b, "kcov merge coverage");
     kcov_merge.rename_step_with_output_arg = false;
-    kcov_merge.addArg(kcov_bin);
+    kcov_merge.addFileArg(kcov_bin);
     kcov_merge.addArg("--merge");
     const coverage_output = kcov_merge.addOutputDirectoryArg(".");
 
     for ([_]*std.Build.Step.Compile{ lsp_tests, lsp_parser_tests }) |test_artifact| {
         const kcov_collect = std.Build.Step.Run.create(b, "kcov collect coverage");
-        kcov_collect.addArg(kcov_bin);
+        kcov_collect.addFileArg(kcov_bin);
         kcov_collect.addArg("--collect-only");
         kcov_collect.addPrefixedDirectoryArg("--include-path=", b.path("."));
         kcov_merge.addDirectoryArg(kcov_collect.addOutputDirectoryArg(test_artifact.name));

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .lsp_kit,
     .version = "0.1.0",
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.17.0-dev.607+456b2ec07",
     .dependencies = .{},
     .paths = .{
         "build.zig",


### PR DESCRIPTION
This does change the usage of hello client subcommand. Before we had an assumption that if only one arg was passedd in, you'd default to the hello server. If you passed more than one in, the second argument is expected to be a path to the server binary.

With the changes to Zig master, we can only pass through the args on the commandline, not inspect them. I've worked around this behavior by passing in the server binary explicitly using a named option over an arg positional.